### PR TITLE
Install dependencies before copying source code in Docker images

### DIFF
--- a/packages/backend/authentication/production.Dockerfile
+++ b/packages/backend/authentication/production.Dockerfile
@@ -2,20 +2,24 @@ FROM node:10-alpine AS build
 
 WORKDIR /app
 
+# Install dependencies
+COPY ./packages/backend/authentication/package.json ./packages/backend/authentication/package.json
+COPY ./packages/backend/data-model/package.json ./packages/backend/data-model/package.json
+COPY ./package.json .
+COPY ./yarn.lock .
+RUN yarn --production
+
+# Copy source code
 COPY ./packages/backend/authentication ./packages/backend/authentication
 COPY ./packages/backend/data-model ./packages/backend/data-model
-COPY ./package.json .
 COPY ./tsconfig.json .
-COPY ./yarn.lock .
-
-RUN yarn --frozen-lockfile --production
 
 FROM node:10-alpine
 
 EXPOSE 5000
 
-COPY --from=build /app /app
-
 WORKDIR /app/packages/backend/authentication
+
+COPY --from=build /app /app
 
 ENTRYPOINT ["node", "dist/index.js"]

--- a/packages/backend/public-api/production.Dockerfile
+++ b/packages/backend/public-api/production.Dockerfile
@@ -2,14 +2,19 @@ FROM node:10-alpine AS build
 
 WORKDIR /app
 
+# Install dependencies
+COPY ./packages/backend/data-model/package.json ./packages/backend/data-model/package.json
+COPY ./packages/backend/public-api/package.json ./packages/backend/public-api/package.json
+COPY ./packages/backend/public-api-context/package.json ./packages/backend/public-api-context/package.json
+COPY ./package.json .
+COPY ./yarn.lock .
+RUN yarn --production
+
+# Copy source code
 COPY ./packages/backend/data-model ./packages/backend/data-model
 COPY ./packages/backend/public-api ./packages/backend/public-api
 COPY ./packages/backend/public-api-context ./packages/backend/public-api-context
-COPY ./package.json .
 COPY ./tsconfig.json .
-COPY ./yarn.lock .
-
-RUN yarn --frozen-lockfile --production
 
 FROM node:10-alpine
 

--- a/packages/frontend/web-client/production.Dockerfile
+++ b/packages/frontend/web-client/production.Dockerfile
@@ -6,15 +6,21 @@ ENV REACT_APP_API_ENDPOINT=$API_ENDPOINT
 
 WORKDIR /app
 
+# Install dependencies
+COPY ./packages/frontend/design-system/package.json ./packages/frontend/design-system/package.json
+COPY ./packages/frontend/web-client/package.json ./packages/frontend/web-client/package.json
+COPY ./packages/libraries/test-utilities/package.json ./packages/libraries/test-utilities/package.json
+COPY ./package.json .
+COPY ./yarn.lock .
+RUN yarn
+
+# Copy source code
 COPY ./packages/frontend/design-system ./packages/frontend/design-system
 COPY ./packages/frontend/web-client ./packages/frontend/web-client
 COPY ./packages/libraries/test-utilities ./packages/libraries/test-utilities
-COPY ./package.json .
 COPY ./tsconfig.json .
 COPY ./tslint.json .
-COPY ./yarn.lock .
 
-RUN yarn --frozen-lockfile
 RUN yarn web-client build
 
 FROM nginx:stable

--- a/packages/tasks/deploy-data-model/Dockerfile
+++ b/packages/tasks/deploy-data-model/Dockerfile
@@ -2,13 +2,17 @@ FROM node:10-alpine
 
 WORKDIR /app
 
-COPY ./packages/backend/data-model ./packages/backend/data-model
-COPY ./scripts ./scripts
+RUN apk --no-cache add curl
+
+# Install dependencies
+COPY ./packages/backend/data-model/package.json ./packages/backend/data-model/package.json
 COPY ./package.json .
 COPY ./yarn.lock .
+RUN yarn
 
-RUN yarn --frozen-lockfile
+# Copy source code
+COPY ./packages/backend/data-model ./packages/backend/data-model
 
-RUN apk --no-cache add curl
+COPY ./scripts ./scripts
 
 ENTRYPOINT ["sh", "-c", "yarn wait-for-prisma && yarn data-model deploy && yarn data-model seed"]

--- a/packages/tasks/integration-tests/Dockerfile
+++ b/packages/tasks/integration-tests/Dockerfile
@@ -2,13 +2,17 @@ FROM node:10-alpine as build
 
 WORKDIR /app
 
-COPY ./packages/tasks/integration-tests ./packages/tasks/integration-tests
-COPY ./scripts ./scripts
+# Install dependencies
+COPY ./packages/tasks/integration-tests/package.json ./packages/tasks/integration-tests/package.json
 COPY ./package.json .
-COPY ./tsconfig.json .
 COPY ./yarn.lock .
+RUN yarn
 
-RUN yarn --frozen-lockfile
+# Copy source code
+COPY ./packages/tasks/integration-tests ./packages/tasks/integration-tests
+COPY ./tsconfig.json .
+
+COPY ./scripts ./scripts
 
 FROM davidchristie/puppeteer
 


### PR DESCRIPTION
This way, changes to the source code do not invalidate the layers containing the dependencies. Those layers remain cached in subsequent builds.